### PR TITLE
mc 1.20: replace minecraft:alternative with minecraft:any_of

### DIFF
--- a/data/armor_statues/predicates/book.json
+++ b/data/armor_statues/predicates/book.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/armor_statues/predicates/mainhand_potion.json
+++ b/data/armor_statues/predicates/mainhand_potion.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/armor_statues/predicates/offhand_potion.json
+++ b/data/armor_statues/predicates/offhand_potion.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:entity_properties",

--- a/data/armor_statues/predicates/savedpose.json
+++ b/data/armor_statues/predicates/savedpose.json
@@ -1,5 +1,5 @@
 {
-  "condition": "minecraft:alternative",
+  "condition": "minecraft:any_of",
   "terms": [
     {
       "condition": "minecraft:reference",


### PR DESCRIPTION
This was the minimum change I had to make to allow armor-statues to work on 1.20. 
PR filed in case it is of use to someone.